### PR TITLE
Fixed a bug where BITRISE_APK_PATH pointed to a path not under BITRISE_DEPLOY_DIR afterwards.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .gows.user.yml
 *.test
 _tmp/
+.idea/

--- a/apkexporter/apkexporter.go
+++ b/apkexporter/apkexporter.go
@@ -105,11 +105,12 @@ func (exporter Exporter) ExportUniversalAPK(aabPath, destDir string, keystoreCon
 	}
 
 	universalAPKName := UniversalAPKBase(aabPath)
-	if err := command.CopyFile(universalAPKPath, filepath.Join(destDir, universalAPKName)); err != nil {
+	destinationPath := filepath.Join(destDir, universalAPKName)
+	if err := command.CopyFile(universalAPKPath, destinationPath); err != nil {
 		return "", err
 	}
 
-	return universalAPKPath, nil
+	return destinationPath, nil
 }
 
 // Prepares the KeystoreConfig for use. For example: download the keystore file or prefix passwords.

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -66,16 +66,10 @@ workflows:
 
   assert-outputs:
     steps:
-    - script:
-        title: Check outputs
+    - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
         inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-
-            if [ -z "$BITRISE_APK_PATH" ] ; then echo "BITRISE_APK_PATH env is empty" ; exit 1 ; fi ;
-            [[ ! -f $BITRISE_APK_PATH ]] && echo "$BITRISE_APK_PATH does not exist" && exit 1
-            exit 0
+        - deploy_dir: $BITRISE_DEPLOY_DIR
+        - deployed_files: BITRISE_APK_PATH
 
   clear-tmp:
     steps:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

I found that, after running this step, `BITRISE_APK_PATH` pointed to a path like `/tmp/universal_apk684916221/universal.apk`. It's not under `BITRISE_DEPLOY_DIR` therefore users may need to move the file into `BITRISE_DEPLOY_DIR` manually if they want it to be.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

 - Fixed the return value of exporter, to return a path pointing to a copied file under `BITRISE_DEPLOY_DIR`.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

This behavior came from https://github.com/bitrise-steplib/bitrise-step-export-universal-apk/blob/0.1.2/apkexporter/apkexporter.go#L102-L112,

```go
	universalAPKPath, err := unzipAPKsArchive(apksPath, tempPath)
	if err != nil {
		return "", err
	}

	universalAPKName := UniversalAPKBase(aabPath)
	if err := command.CopyFile(universalAPKPath, filepath.Join(destDir, universalAPKName)); err != nil {
		return "", err
	}

	return universalAPKPath, nil
```

It returns `universalAPKPath` which is under a temp directory, although the universal APK has been copied into `destDir` (= `BITRISE_DEPLOY_DIR `). And also, it turned out that this step silently put a copy of the universal APK file into `BITRISE_DEPLOY_DIR` as well.





### Decisions

<!-- Please list decisions that were made for this change. -->

I think the exporter should return the copy destination path instead, then `BITRISE_APK_PATH` will point to the  appropriate path under `BITRISE_DEPLOY_DIR`.

As mentioned above, the step actually copied into the destination path, so it will still be backward compatible.
Those who would have moved the temp file into `BITRISE_DEPLOY_DIR` manually may need to update their workflow a bit after this change though.
